### PR TITLE
add toggle for mail type

### DIFF
--- a/src/components/pages/Newsletter/index.tsx
+++ b/src/components/pages/Newsletter/index.tsx
@@ -20,6 +20,7 @@ import {
   removeFile,
   updateUploadColor,
   updateUploadDoublesided,
+  updateMailClass,
 } from 'src/redux/modules/newsletter';
 import { loadTags } from 'src/redux/modules/tag';
 import ConfirmSendModal from './ConfirmSendModal';
@@ -54,6 +55,7 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
       logout,
       updateUploadDoublesided,
       updateUploadColor,
+      updateMailClass,
     },
     dispatch,
   );
@@ -79,6 +81,7 @@ const UnconnectedNewsletter: React.FC<PropsFromRedux> = ({
   logout,
   updateUploadColor,
   updateUploadDoublesided,
+  updateMailClass,
 }) => {
   const [newsletter, setNewsletter] = useState<DraftNewsletter>(
     {} as DraftNewsletter,
@@ -112,6 +115,7 @@ const UnconnectedNewsletter: React.FC<PropsFromRedux> = ({
         tags: newsletters.uploadSelectedTags,
         color: newsletters.uploadColor,
         double_sided: newsletters.uploadDoubleSided,
+        standardMail: newsletters.standardMail,
       });
       const obj = URL.createObjectURL(newsletters.uploadedFile);
       getPageCount(obj);
@@ -251,6 +255,15 @@ const UnconnectedNewsletter: React.FC<PropsFromRedux> = ({
                 setValue={updateUploadDoublesided}
                 defaultLabel="Single-Sided"
                 otherLabel="Double-Sided"
+              />
+            </div>
+            <div className="d-flex flex-column mt-3 mw-50">
+              <span className="p5 font-weight-bold">Mail Class</span>
+              <Toggle
+                value={newsletters.standardMail}
+                setValue={updateMailClass}
+                defaultLabel="First Class"
+                otherLabel="Standard Mail"
               />
             </div>
             <div className="d-flex flex-column my-3 mw-50">

--- a/src/redux/modules/newsletter.ts
+++ b/src/redux/modules/newsletter.ts
@@ -20,6 +20,7 @@ const LOADING = 'newsletter/LOADING';
 const ERROR = 'newsletter/ERROR';
 const UPDATE_DOUBLESIDED = 'newsletter/UPDATE_DOUBLESIDED';
 const UPDATE_COLOR = 'newsletter/UPDATE_COLOR';
+const UPDATE_MAIL_CLASS = 'newsletter/UPDATE_MAIL_CLASS';
 
 interface LoadingAction {
   type: typeof LOADING;
@@ -99,6 +100,11 @@ interface UpdateColorAction {
   payload: boolean;
 }
 
+interface UpdateMailClass {
+  type: typeof UPDATE_MAIL_CLASS;
+  payload: boolean;
+}
+
 type NewsletterActionTypes =
   | SetNameAction
   | AddFilterAction
@@ -115,7 +121,8 @@ type NewsletterActionTypes =
   | LoadingAction
   | ErrorAction
   | UpdateColorAction
-  | UpdateDoublesidedAction;
+  | UpdateDoublesidedAction
+  | UpdateMailClass;
 
 // Action creators
 export const setName = (name: string): NewsletterActionTypes => {
@@ -229,6 +236,13 @@ export const loading = (): NewsletterActionTypes => {
   };
 };
 
+export const updateMailClass = (value: boolean): NewsletterActionTypes => {
+  return {
+    type: UPDATE_MAIL_CLASS,
+    payload: value,
+  };
+};
+
 // Reducer
 const initialState: NewsletterState = {
   newsletterName: '',
@@ -241,6 +255,7 @@ const initialState: NewsletterState = {
   loading: false,
   uploadDoubleSided: false,
   uploadColor: true,
+  standardMail: true,
 };
 
 export function newsletterReducer(
@@ -345,6 +360,11 @@ export function newsletterReducer(
       return {
         ...state,
         uploadColor: action.payload,
+      };
+    case UPDATE_MAIL_CLASS:
+      return {
+        ...state,
+        standardMail: action.payload,
       };
     default:
       return state;

--- a/src/services/Api/newsletters.ts
+++ b/src/services/Api/newsletters.ts
@@ -45,6 +45,7 @@ export async function createNewsletter(
       page_count: pageCount,
       double_sided: newsletter.double_sided,
       color: newsletter.color,
+      mail_type: newsletter.standardMail ? 'usps_standard' : 'usps_first_class',
     }),
   };
   const response = await fetch(

--- a/src/typings/Newsletter.d.ts
+++ b/src/typings/Newsletter.d.ts
@@ -4,6 +4,7 @@ interface DraftNewsletter {
   tags: Tags[];
   color: boolean;
   double_sided: boolean;
+  standardMail: boolean;
 }
 
 interface NewsletterLog {

--- a/src/typings/state/NewsletterState.d.ts
+++ b/src/typings/state/NewsletterState.d.ts
@@ -9,4 +9,5 @@ interface NewsletterState {
   selectedFilters: Tag[];
   error: ErrorResponse;
   loading: boolean;
+  standardMail: boolean;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

### Before: All mail had to be sent as first class

### After: when making a newsletter you can choose to make it first class or standard mail with a toggle

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Parole Illinois' newsletter is waiting for the ability to send as standard mail

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually in Brave and chrome by sending requests with the toggle and verifying that the local database reflected the appropriate toggle setting.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
