### PR TITLE
add table badge and filter failed letters

### DIFF
--- a/src/components/pages/NewsletterHistory/index.tsx
+++ b/src/components/pages/NewsletterHistory/index.tsx
@@ -171,6 +171,7 @@ const UnconnectedNewsletterHistory: React.FC<PropsFromRedux> = ({
                 <th>Estimated Arrival</th>
                 <th>Tags</th>
                 <th>File</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -202,6 +203,13 @@ const UnconnectedNewsletterHistory: React.FC<PropsFromRedux> = ({
                           rel="noopener noreferrer">
                           Link
                         </a>
+                      </td>
+                      <td>
+                        {newsletter.status === 'error' ? (
+                          <span className="badge badge-danger">error</span>
+                        ) : (
+                          ''
+                        )}
                       </td>
                     </>
                   </tr>

--- a/src/services/Api/newsletters.ts
+++ b/src/services/Api/newsletters.ts
@@ -67,6 +67,7 @@ export async function createNewsletter(
     totalLettersCount: body.data.total_letter_count,
     estimatedArrival: null,
     tags: [],
+    status: null,
   };
   if (body.data.estimated_arrival) {
     newsletterData.estimatedArrival = new Date(body.data.estimated_arrival);
@@ -121,6 +122,7 @@ export async function fetchNewsletters(
     returned_count: number;
     created_at: string;
     estimated_arrival: string | null;
+    status: string;
     tags: t[];
   }
   const newslettersData: NewsletterLog[] = [];
@@ -136,6 +138,7 @@ export async function fetchNewsletters(
       estimatedArrival: null,
       tags: [],
       totalLettersCount: newsletter.total_letter_count,
+      status: newsletter.status,
     };
     if (newsletter.estimated_arrival) {
       newsletterData.estimatedArrival = new Date(newsletter.estimated_arrival);
@@ -146,9 +149,17 @@ export async function fetchNewsletters(
         numContacts: tag.total_contacts,
         label: tag.label,
       };
+
       newsletterData.tags.push(tagData);
     });
-    newslettersData.push(newsletterData);
+    var yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    if (
+      newsletterData.status !== 'error' ||
+      newsletterData.creationDate > yesterday
+    ) {
+      newslettersData.push(newsletterData);
+    }
   });
   return newslettersData;
 }

--- a/src/services/Api/newsletters.ts
+++ b/src/services/Api/newsletters.ts
@@ -1,4 +1,5 @@
 import url from 'url';
+import { subDays } from 'date-fns';
 import { API_URL, BASE_URL } from './base';
 
 export async function createNewsletter(
@@ -152,8 +153,7 @@ export async function fetchNewsletters(
 
       newsletterData.tags.push(tagData);
     });
-    var yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterday = subDays(new Date(), 1);
     if (
       newsletterData.status !== 'error' ||
       newsletterData.creationDate > yesterday

--- a/src/typings/Newsletter.d.ts
+++ b/src/typings/Newsletter.d.ts
@@ -18,4 +18,5 @@ interface NewsletterLog {
   creationDate: Date;
   estimatedArrival: Date | null;
   tags: Tags[];
+  status: string | null;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

### Before
All newsletters presented the same regardless of whether they were sent or an error.

### After
Newsletters sent in error have a red error badge in the table for 24 hours, after which point they disappear.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #42  and #41 



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally by first verifying that newsletters messages would recieve the error badge and then verifying that the erroneous newsletters would be removed after 24 hours.

## Screenshots (if appropriate):


Before implementing 24 hour filter (badges on right)
![Screen Shot 2020-09-03 at 8 57 33 PM](https://user-images.githubusercontent.com/22424909/92188211-f46bd980-ee29-11ea-8513-7bc671b8c2ba.png)

After implementing 24 hour filter
![Screen Shot 2020-09-03 at 9 06 55 PM](https://user-images.githubusercontent.com/22424909/92188228-03eb2280-ee2a-11ea-8dae-a6cca44f435d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
