### PR TITLE
loading volunteers

### DIFF
--- a/src/components/pages/Volunteers/index.tsx
+++ b/src/components/pages/Volunteers/index.tsx
@@ -173,7 +173,7 @@ const UnconnectedVolunteers: React.FC<PropsFromRedux> = ({
         ))}
       </section>
 
-      {volunteers.loading_details && spinner}
+      {(volunteers.loading || volunteers.loading_details) && spinner}
 
       {problemLoadingDetails && (
         <Container id="problem-loading-info">

--- a/src/components/pages/Volunteers/index.tsx
+++ b/src/components/pages/Volunteers/index.tsx
@@ -146,12 +146,8 @@ const UnconnectedVolunteers: React.FC<PropsFromRedux> = ({
     </Container>
   );
 
-  if (volunteers.loading) {
-    return spinner;
-  }
-
   let page_id = 'content';
-  if (volunteers.loading_details) {
+  if (volunteers.loading) {
     page_id = 'faded';
   }
 
@@ -182,7 +178,7 @@ const UnconnectedVolunteers: React.FC<PropsFromRedux> = ({
         ))}
       </section>
 
-      {volunteers.loading_details && spinner}
+      {volunteers.loading && spinner}
 
       {problemLoadingDetails && (
         <Container id="problem-loading-info">

--- a/src/components/pages/Volunteers/index.tsx
+++ b/src/components/pages/Volunteers/index.tsx
@@ -146,15 +146,20 @@ const UnconnectedVolunteers: React.FC<PropsFromRedux> = ({
     </Container>
   );
 
-  let page_id = 'content';
+  let volunteers_id,
+    details_id = 'content';
   if (volunteers.loading) {
-    page_id = 'faded';
+    volunteers_id = 'faded';
+    details_id = 'faded';
+  }
+  if (volunteers.loading_details) {
+    details_id = 'faded';
   }
 
   return (
     <div className="d-flex flex-row">
       <section
-        id={page_id}
+        id={volunteers_id}
         className="volunteers-list-sidebar d-flex flex-column mw-27 border-right pl-4 shadow-sm bg-white rounded">
         <div className="d-flex flex-row justify-content-between align-items-center mt-5 mb-3 mr-3 ">
           <span className="black-500 p3">Volunteers</span>
@@ -178,7 +183,7 @@ const UnconnectedVolunteers: React.FC<PropsFromRedux> = ({
         ))}
       </section>
 
-      {volunteers.loading && spinner}
+      {volunteers.loading_details && spinner}
 
       {problemLoadingDetails && (
         <Container id="problem-loading-info">
@@ -191,7 +196,7 @@ const UnconnectedVolunteers: React.FC<PropsFromRedux> = ({
 
       {volunteers.selected_volunteer.details && (
         <section
-          id={page_id}
+          id={details_id}
           className="d-flex flex-column p-5 m-5 bg-white shadow-sm w-50">
           <span className="p3">Letters</span>
           <div className="d-flex flex-row">
@@ -226,7 +231,7 @@ const UnconnectedVolunteers: React.FC<PropsFromRedux> = ({
       {volunteers.selected_volunteer.details && org && (
         <VolunteerDetails
           volunteer={volunteers.selected_volunteer}
-          page_id={page_id}
+          page_id={details_id}
           showUpdateForm={showUpdateForm}
           handleUpdateClose={handleUpdateClose}
           handleUpdateShow={handleUpdateShow}

--- a/src/components/pages/Volunteers/index.tsx
+++ b/src/components/pages/Volunteers/index.tsx
@@ -146,20 +146,10 @@ const UnconnectedVolunteers: React.FC<PropsFromRedux> = ({
     </Container>
   );
 
-  let volunteers_id,
-    details_id = 'content';
-  if (volunteers.loading) {
-    volunteers_id = 'faded';
-    details_id = 'faded';
-  }
-  if (volunteers.loading_details) {
-    details_id = 'faded';
-  }
-
   return (
     <div className="d-flex flex-row">
       <section
-        id={volunteers_id}
+        id={volunteers.loading ? 'faded' : ''}
         className="volunteers-list-sidebar d-flex flex-column mw-27 border-right pl-4 shadow-sm bg-white rounded">
         <div className="d-flex flex-row justify-content-between align-items-center mt-5 mb-3 mr-3 ">
           <span className="black-500 p3">Volunteers</span>
@@ -196,7 +186,7 @@ const UnconnectedVolunteers: React.FC<PropsFromRedux> = ({
 
       {volunteers.selected_volunteer.details && (
         <section
-          id={details_id}
+          id={volunteers.loading || volunteers.loading_details ? 'faded' : ''}
           className="d-flex flex-column p-5 m-5 bg-white shadow-sm w-50">
           <span className="p3">Letters</span>
           <div className="d-flex flex-row">
@@ -231,7 +221,9 @@ const UnconnectedVolunteers: React.FC<PropsFromRedux> = ({
       {volunteers.selected_volunteer.details && org && (
         <VolunteerDetails
           volunteer={volunteers.selected_volunteer}
-          page_id={details_id}
+          page_id={
+            volunteers.loading || volunteers.loading_details ? 'faded' : ''
+          }
           showUpdateForm={showUpdateForm}
           handleUpdateClose={handleUpdateClose}
           handleUpdateShow={handleUpdateShow}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Instead of greying the entire screen when you pick another volunteer from the list, only greys the center + right boxes. leaves sidebar alone. 
2. makes boxes visible with spinner while reloading volunteer pg. Before, the entire page used to go blank with a spinner in the center. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
[https://github.com/Ameelio/letters-organizations-client/issues/48](url)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
